### PR TITLE
Add theme options

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,8 +1,37 @@
+:root {
+    --bg-color: #f5f5f5;
+    --controls-bg: #fff;
+    --info-bg: #fff;
+    --text-color: #333;
+    --secondary-text-color: #666;
+    --border-color: #ddd;
+    --button-bg: #4CAF50;
+    --button-hover-bg: #45a049;
+    --button-active-bg: #357a38;
+    --tuner-bg: #f0f0f0;
+    --freq-info-color: #2c5282;
+}
+
+.dark-theme {
+    --bg-color: #1a1a1a;
+    --controls-bg: #333;
+    --info-bg: #333;
+    --text-color: #eee;
+    --secondary-text-color: #aaa;
+    --border-color: #555;
+    --button-bg: #4CAF50;
+    --button-hover-bg: #45a049;
+    --button-active-bg: #357a38;
+    --tuner-bg: #444;
+    --freq-info-color: #63b3ed;
+}
+
 body {
     font-family: Arial, sans-serif;
     margin: 0;
     padding: 20px;
-    background-color: #f5f5f5;
+    background-color: var(--bg-color);
+    color: var(--text-color);
 }
 
 .container {
@@ -13,12 +42,12 @@ body {
 
 h1 {
     text-align: center;
-    color: #333;
+    color: var(--text-color);
 }
 
 .version {
     font-size: 0.4em;
-    color: #666;
+    color: var(--secondary-text-color);
     vertical-align: super;
     margin-left: 5px;
     font-weight: normal;
@@ -31,7 +60,7 @@ h1 {
     gap: 20px;
     margin: 20px 0;
     padding: 15px;
-    background-color: #fff;
+    background-color: var(--controls-bg);
     border-radius: 8px;
     box-shadow: 0 2px 4px rgba(0,0,0,0.1);
 }
@@ -39,7 +68,8 @@ h1 {
 .tuning-section,
 .sound-section,
 .scale-section,
-.mode-section {
+.mode-section,
+.theme-section {
     display: flex;
     align-items: center;
     gap: 10px;
@@ -95,7 +125,7 @@ h1 {
     width: 26px;
     height: 26px;
     border-radius: 50%;
-    border: 3px solid #333;
+    border: 3px solid var(--text-color);
     background-color: rgba(255, 255, 255, 1);
     opacity: 1;
     color: rgba(0, 0, 0, 1);
@@ -176,7 +206,7 @@ h1 {
 }
 
 .info-panel {
-    background-color: #fff;
+    background-color: var(--info-bg);
     padding: 20px;
     border-radius: 8px;
     margin-top: 20px;
@@ -186,24 +216,24 @@ h1 {
 select, button {
     padding: 8px 12px;
     border-radius: 4px;
-    border: 1px solid #ddd;
-    background-color: #fff;
+    border: 1px solid var(--border-color);
+    background-color: var(--controls-bg);
     cursor: pointer;
 }
 
 button {
-    background-color: #4CAF50;
+    background-color: var(--button-bg);
     color: white;
     border: none;
     transition: background-color 0.3s ease;
 }
 
 button:hover {
-    background-color: #45a049;
+    background-color: var(--button-hover-bg);
 }
 
 button.active {
-    background-color: #357a38;
+    background-color: var(--button-active-bg);
 }
 
 .tuner-toggle {
@@ -212,7 +242,7 @@ button.active {
     gap: 8px;
     margin-left: 20px;
     padding: 8px;
-    background-color: #f0f0f0;
+    background-color: var(--tuner-bg);
     border-radius: 4px;
 }
 
@@ -229,12 +259,12 @@ button.active {
 
 #frequency-info {
     margin-top: 10px;
-    color: #2c5282;
+    color: var(--freq-info-color);
     font-family: monospace;
     font-size: 1.1em;
 }
 
 #scale-info {
     margin-top: 10px;
-    color: #666;
+    color: var(--secondary-text-color);
 }

--- a/static/js/guitar.js
+++ b/static/js/guitar.js
@@ -474,4 +474,20 @@ class Guitar {
 // Initialize the guitar when the page loads
 window.addEventListener('load', () => {
     new Guitar();
+
+    const themeSelect = document.getElementById('theme');
+    const applyTheme = (theme) => {
+        document.body.classList.toggle('dark-theme', theme === 'dark');
+    };
+
+    const savedTheme = localStorage.getItem('theme') || 'light';
+    applyTheme(savedTheme);
+    if (themeSelect) {
+        themeSelect.value = savedTheme;
+        themeSelect.addEventListener('change', (e) => {
+            const newTheme = e.target.value;
+            applyTheme(newTheme);
+            localStorage.setItem('theme', newTheme);
+        });
+    }
 });

--- a/templates/index.html
+++ b/templates/index.html
@@ -76,6 +76,14 @@
                     <input type="checkbox" id="tunerMode">
                 </div>
             </div>
+
+            <div class="theme-section">
+                <label for="theme">Theme:</label>
+                <select id="theme">
+                    <option value="light">Light</option>
+                    <option value="dark">Dark</option>
+                </select>
+            </div>
         </div>
 
         <div id="guitar-neck" class="guitar-neck"></div>


### PR DESCRIPTION
## Summary
- add CSS variables and dark-theme overrides
- allow selecting theme with new dropdown
- persist theme choice in localStorage

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684924aa2d94832eb6dd7267502bbd3f