### PR TITLE
Fix active note cleanup

### DIFF
--- a/static/js/guitar.js
+++ b/static/js/guitar.js
@@ -466,7 +466,10 @@ class Guitar {
             this.playNoteInTunerMode(synth, noteValue, frequency);
         } else {
             synth.triggerAttackRelease(noteValue, '2n');
-            this.activeNotes.add({ synth, note: noteValue });
+            const noteInfo = { synth, note: noteValue };
+            this.activeNotes.add(noteInfo);
+            // Remove the note from the active set once it has finished playing
+            setTimeout(() => this.activeNotes.delete(noteInfo), 2000);
         }
     }
 }


### PR DESCRIPTION
## Summary
- clean up note tracking when playing notes
- ensure file ends with newline

## Testing
- `python -m py_compile app.py`
- `node -e "require('fs').readFileSync('static/js/guitar.js','utf8');"`

------
https://chatgpt.com/codex/tasks/task_e_68492480e934832ebc9cbedbdf2a0b0e