### PR TITLE
Add pytest test for home route

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 flask==3.0.0
 flask-cors==4.0.0
+pytest==7.4.2

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,6 @@
+from app import app
+
+def test_index():
+    with app.test_client() as client:
+        response = client.get('/')
+        assert response.status_code == 200


### PR DESCRIPTION
## Summary
- add pytest as a dev requirement
- write a basic test using Flask's test client

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684941b5f448832eb051af6db3b6561b